### PR TITLE
Add client parameter to BigQuery request

### DIFF
--- a/src/context/AsoDataContext.tsx
+++ b/src/context/AsoDataContext.tsx
@@ -18,7 +18,7 @@ interface BigQueryMeta {
   totalRows: number;
   executionTimeMs: number;
   queryParams: {
-    organizationId: string;
+    client: string;
     dateRange: { from: string; to: string } | null;
     limit: number;
   };

--- a/src/hooks/useBigQueryData.ts
+++ b/src/hooks/useBigQueryData.ts
@@ -24,7 +24,7 @@ interface BigQueryMeta {
   totalRows: number;
   executionTimeMs: number;
   queryParams: {
-    organizationId: string;
+    client: string;
     dateRange: { from: string; to: string } | null;
     selectedApps?: string[];
     trafficSources?: string[]; // Add traffic source filtering
@@ -86,11 +86,11 @@ export const useBigQueryData = (
           trafficSources
         });
 
-        // Use the first client as organizationId for now
-        const organizationId = clientList[0] || 'yodel_pimsleur';
-        
+        // Use the first client as identifier for now
+        const client = clientList[0] || 'yodel_pimsleur';
+
         const requestBody = {
-          organizationId,
+          client,
           dateRange: {
             from: dateRange.from.toISOString().split('T')[0],
             to: dateRange.to.toISOString().split('T')[0]

--- a/src/pages/dashboard.tsx
+++ b/src/pages/dashboard.tsx
@@ -89,7 +89,7 @@ const Dashboard: React.FC = () => {
             <p className="text-zinc-400 max-w-md">
               {meta ? (
                 <>
-                  No results found for organization "{meta.queryParams.organizationId}" 
+                  No results found for organization "{meta.queryParams.client}"
                   {meta.queryParams.dateRange && (
                     <> between {meta.queryParams.dateRange.from} and {meta.queryParams.dateRange.to}</>
                   )}.
@@ -104,7 +104,7 @@ const Dashboard: React.FC = () => {
           {meta && process.env.NODE_ENV === 'development' && (
             <div className="mt-4 p-3 bg-zinc-800/50 rounded-lg text-xs text-zinc-400 text-left">
               <div className="font-medium text-zinc-300 mb-2">Debug Information:</div>
-              <div>Organization ID: {meta.queryParams.organizationId}</div>
+              <div>Organization ID: {meta.queryParams.client}</div>
               <div>Date Range: {meta.queryParams.dateRange ? 
                 `${meta.queryParams.dateRange.from} to ${meta.queryParams.dateRange.to}` : 
                 'No date filter'

--- a/supabase/functions/bigquery-aso-data/index.ts
+++ b/supabase/functions/bigquery-aso-data/index.ts
@@ -20,7 +20,7 @@ interface BigQueryCredentials {
 }
 
 interface BigQueryRequest {
-  organizationId: string;
+  client: string;
   dateRange?: {
     from: string;
     to: string;
@@ -112,7 +112,7 @@ serve(async (req) => {
 
     let body: BigQueryRequest;
     if (req.method === 'GET') {
-      body = { organizationId: "84728f94-91db-4f9c-b025-5221fbed4065", limit: 100 };
+      body = { client: "84728f94-91db-4f9c-b025-5221fbed4065", limit: 100 };
     } else {
       try {
         body = await req.json();
@@ -131,14 +131,14 @@ serve(async (req) => {
       }
     }
 
-    if (!body.organizationId) {
-      throw new Error('organizationId is required');
+    if (!body.client) {
+      throw new Error('client is required');
     }
 
     // Get approved apps for this organization
-    console.log('🔍 [BigQuery] Getting approved apps for organization:', body.organizationId);
+    console.log('🔍 [BigQuery] Getting approved apps for organization:', body.client);
     const { data: approvedApps, error: approvedAppsError } = await supabaseClient
-      .rpc('get_approved_apps', { p_organization_id: body.organizationId });
+      .rpc('get_approved_apps', { p_organization_id: body.client });
 
     if (approvedAppsError) {
       console.error('❌ [BigQuery] Failed to get approved apps:', approvedAppsError);
@@ -278,7 +278,7 @@ serve(async (req) => {
       
       return {
         date: fields[0]?.v || null,
-        organization_id: fields[1]?.v || body.organizationId,
+        organization_id: fields[1]?.v || body.client,
         traffic_source: mapTrafficSourceToDisplay(originalTrafficSource), // Map to display name
         traffic_source_raw: originalTrafficSource, // Keep original for debugging
         impressions: parseInt(fields[3]?.v || '0'),
@@ -305,7 +305,7 @@ serve(async (req) => {
           const { error: upsertError } = await supabaseClient
             .from('organization_apps')
             .upsert({
-              organization_id: body.organizationId,
+              organization_id: body.client,
               app_identifier: client,
               app_name: client,
               data_source: 'bigquery',
@@ -348,7 +348,7 @@ serve(async (req) => {
           totalRows: parseInt(queryResult.totalRows || '0'),
           executionTimeMs,
           queryParams: {
-            organizationId: body.organizationId,
+            client: body.client,
             dateRange: body.dateRange || null,
             selectedApps: body.selectedApps || null,
             trafficSources: body.trafficSources || null,


### PR DESCRIPTION
## Summary
- update BigQuery edge function to expect `client` instead of `organizationId`
- send `client` from hook and expose in context meta
- reflect new meta field in dashboard

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685d1d76c34083268bff9c3356778256