### PR TITLE
Switch meta to client param

### DIFF
--- a/src/context/AsoDataContext.tsx
+++ b/src/context/AsoDataContext.tsx
@@ -18,7 +18,7 @@ interface BigQueryMeta {
   totalRows: number;
   executionTimeMs: number;
   queryParams: {
-    organizationId: string;
+    client: string;
     dateRange: { from: string; to: string } | null;
     limit: number;
   };

--- a/src/hooks/useBigQueryData.ts
+++ b/src/hooks/useBigQueryData.ts
@@ -24,7 +24,7 @@ interface BigQueryMeta {
   totalRows: number;
   executionTimeMs: number;
   queryParams: {
-    organizationId: string;
+    client: string;
     dateRange: { from: string; to: string } | null;
     selectedApps?: string[];
     trafficSources?: string[]; // Add traffic source filtering
@@ -86,11 +86,11 @@ export const useBigQueryData = (
           trafficSources
         });
 
-        // Use the first client as organizationId for now
-        const organizationId = clientList[0] || 'yodel_pimsleur';
-        
+        // Use the first client for now
+        const client = clientList[0] || 'yodel_pimsleur';
+
         const requestBody = {
-          organizationId,
+          client,
           dateRange: {
             from: dateRange.from.toISOString().split('T')[0],
             to: dateRange.to.toISOString().split('T')[0]

--- a/src/pages/dashboard.tsx
+++ b/src/pages/dashboard.tsx
@@ -89,7 +89,7 @@ const Dashboard: React.FC = () => {
             <p className="text-zinc-400 max-w-md">
               {meta ? (
                 <>
-                  No results found for organization "{meta.queryParams.organizationId}" 
+                  No results found for client "{meta.queryParams.client}"
                   {meta.queryParams.dateRange && (
                     <> between {meta.queryParams.dateRange.from} and {meta.queryParams.dateRange.to}</>
                   )}.
@@ -104,7 +104,7 @@ const Dashboard: React.FC = () => {
           {meta && process.env.NODE_ENV === 'development' && (
             <div className="mt-4 p-3 bg-zinc-800/50 rounded-lg text-xs text-zinc-400 text-left">
               <div className="font-medium text-zinc-300 mb-2">Debug Information:</div>
-              <div>Organization ID: {meta.queryParams.organizationId}</div>
+              <div>Client: {meta.queryParams.client}</div>
               <div>Date Range: {meta.queryParams.dateRange ? 
                 `${meta.queryParams.dateRange.from} to ${meta.queryParams.dateRange.to}` : 
                 'No date filter'


### PR DESCRIPTION
## Summary
- refactor BigQuery hooks to send `client` instead of `organizationId`
- adjust `BigQueryMeta` to expose `meta.queryParams.client`
- update dashboard to show the client in the empty data debug message

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685d1f34d15483269be759cd99c435f7