### PR TITLE
Fix metadata preservation

### DIFF
--- a/src/context/AsoDataContext.tsx
+++ b/src/context/AsoDataContext.tsx
@@ -164,9 +164,12 @@ export const AsoDataProvider: React.FC<AsoDataProviderProps> = ({ children }) =>
 
   // **PRESERVATION: Handle discovery metadata separately**
   useEffect(() => {
-    if (currentDataSource === 'bigquery' && 
-        bigQueryResult.meta?.availableTrafficSources &&
-        bigQueryResult.meta.availableTrafficSources.length > discoveryMetadata.length) {
+    if (
+      currentDataSource === 'bigquery' &&
+      bigQueryResult.meta?.availableTrafficSources &&
+      bigQueryResult.meta.availableTrafficSources.length > discoveryMetadata.length &&
+      !discoveryMetadata.every(src => bigQueryResult.meta!.availableTrafficSources?.includes(src))
+    ) {
       console.log('🔒 [Context] Preserving discovery metadata:', bigQueryResult.meta.availableTrafficSources);
       setDiscoveryMetadata(bigQueryResult.meta.availableTrafficSources);
     }


### PR DESCRIPTION
## Summary
- avoid overwriting a broader traffic-source set with a narrower one in `AsoDataContext`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `bun test` *(fails: Cannot find module '@testing-library/react')*

------
https://chatgpt.com/codex/tasks/task_e_68640be0a4608326a6e9b6938f65796c