### PR TITLE
Fix dependency for filter reapplication

### DIFF
--- a/src/context/AsoDataContext.tsx
+++ b/src/context/AsoDataContext.tsx
@@ -215,7 +215,7 @@ export const AsoDataProvider: React.FC<AsoDataProviderProps> = ({ children }) =>
       console.log('🔄 [AsoDataContext] Reapplying saved traffic source filters:', savedFilters.trafficSources);
       setFilters(prev => ({ ...prev, trafficSources: savedFilters.trafficSources as string[] }));
     }
-  }, [firstQueryCompleted, discoveryMetadata.length]);
+  }, [firstQueryCompleted, discoveryMetadata.length, filters.trafficSources.length]);
 
   // **COMPUTATION: Determine best available sources**
   const bestAvailableTrafficSources = useMemo(() => {


### PR DESCRIPTION
## Summary
- ensure filter reapplication effect re-runs when traffic source count changes

## Testing
- `npm run lint` *(fails: 302 errors)*
- `npm run dev` *(starts Vite dev server)*

------
https://chatgpt.com/codex/tasks/task_e_6864197bc8ec83268290c8e3a71d6d15