### PR TITLE
Fix discovery log effect dependencies

### DIFF
--- a/src/context/AsoDataContext.tsx
+++ b/src/context/AsoDataContext.tsx
@@ -108,7 +108,7 @@ export const AsoDataProvider: React.FC<AsoDataProviderProps> = ({ children }) =>
     if (filters.trafficSources.length === 0 && !firstQueryCompleted) {
       console.log('🚀 [AsoDataContext] Initial discovery query running with no traffic source filter');
     }
-  }, []);
+  }, [filters.trafficSources, firstQueryCompleted]);
 
   // Enhanced filter change logging with state validation
   useEffect(() => {


### PR DESCRIPTION
## Summary
- log the discovery query trigger with current filters

## Testing
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686417c7502483268341429dd4417f3e