### PR TITLE
Implement filter touch tracking

### DIFF
--- a/src/components/Filters/AnalyticsTrafficSourceFilter.tsx
+++ b/src/components/Filters/AnalyticsTrafficSourceFilter.tsx
@@ -74,7 +74,7 @@ const AnalyticsTrafficSourceFilter: React.FC<AnalyticsTrafficSourceFilterProps> 
   placeholder = "All Traffic Sources",
   widthClass = "w-full md:w-80"
 }) => {
-  const { data, availableTrafficSources } = useAsoData();
+  const { data, availableTrafficSources, setUserTouchedFilters } = useAsoData();
   const [isOpen, setIsOpen] = useState(false);
   const [searchTerm, setSearchTerm] = useState("");
   
@@ -125,27 +125,39 @@ const AnalyticsTrafficSourceFilter: React.FC<AnalyticsTrafficSourceFilterProps> 
   }, [allAvailableSources, searchTerm]);
   
   // Memoized handlers for performance
-  const handleSourceToggle = useMemo(() => (source: string, checked: boolean) => {
-    if (disabledSources.includes(source)) return;
-    
-    const newSources = checked 
-      ? [...selectedSources, source].filter((s, i, arr) => arr.indexOf(s) === i)
-      : selectedSources.filter(s => s !== source);
-    onChange(newSources);
-  }, [selectedSources, onChange, disabledSources]);
+  const handleSourceToggle = useMemo(
+    () => (source: string, checked: boolean) => {
+      if (disabledSources.includes(source)) return;
+
+      const newSources = checked
+        ? [...selectedSources, source].filter((s, i, arr) => arr.indexOf(s) === i)
+        : selectedSources.filter(s => s !== source);
+      setUserTouchedFilters(true);
+      onChange(newSources);
+    },
+    [selectedSources, onChange, disabledSources, setUserTouchedFilters]
+  );
   
-  const handleSelectAll = useMemo(() => () => {
-    if (!allowSelectAll) return;
-    const enabledSources = allAvailableSources.filter(source => 
-      !disabledSources.includes(source)
-    );
-    onChange([...enabledSources]);
-  }, [allowSelectAll, allAvailableSources, disabledSources, onChange]);
+  const handleSelectAll = useMemo(
+    () => () => {
+      if (!allowSelectAll) return;
+      const enabledSources = allAvailableSources.filter(
+        source => !disabledSources.includes(source)
+      );
+      setUserTouchedFilters(true);
+      onChange([...enabledSources]);
+    },
+    [allowSelectAll, allAvailableSources, disabledSources, onChange, setUserTouchedFilters]
+  );
   
-  const handleClearAll = useMemo(() => () => {
-    if (!allowClear) return;
-    onChange([]);
-  }, [allowClear, onChange]);
+  const handleClearAll = useMemo(
+    () => () => {
+      if (!allowClear) return;
+      setUserTouchedFilters(true);
+      onChange([]);
+    },
+    [allowClear, onChange, setUserTouchedFilters]
+  );
   
   // Memoized display text for performance
   const displayText = useMemo(() => {
@@ -177,7 +189,13 @@ const AnalyticsTrafficSourceFilter: React.FC<AnalyticsTrafficSourceFilterProps> 
   
   return (
     <div className={widthClass}>
-      <Popover open={isOpen} onOpenChange={setIsOpen}>
+      <Popover
+        open={isOpen}
+        onOpenChange={(open) => {
+          setIsOpen(open);
+          setUserTouchedFilters(true);
+        }}
+      >
         <PopoverTrigger asChild>
           <Button 
             variant="outline" 

--- a/src/pages/dashboard.tsx
+++ b/src/pages/dashboard.tsx
@@ -16,14 +16,15 @@ import { AlertCircle, Calendar, Database, Filter } from "lucide-react";
 
 const Dashboard: React.FC = () => {
   const [excludeAsa, setExcludeAsa] = useState(false);
-  const { 
-    data, 
-    loading, 
-    filters, 
-    setFilters, 
-    currentDataSource, 
+  const {
+    data,
+    loading,
+    filters,
+    setFilters,
+    setUserTouchedFilters,
+    currentDataSource,
     dataSourceStatus,
-    meta 
+    meta
   } = useAsoData();
 
   // Debounced filter updates to prevent excessive API calls
@@ -45,7 +46,8 @@ const Dashboard: React.FC = () => {
       isEmpty: sources.length === 0,
       filterDecision: sources.length === 0 ? 'CLEAR_FILTER_SHOW_ALL' : 'APPLY_SPECIFIC_FILTER'
     });
-    
+
+    setUserTouchedFilters(true);
     setFilters(prev => ({
       ...prev,
       trafficSources: sources
@@ -60,6 +62,7 @@ const Dashboard: React.FC = () => {
   // Update exclude ASA logic to work with clear filter state
   useEffect(() => {
     if (excludeAsa) {
+      setUserTouchedFilters(true);
       setFilters(prev => ({
         ...prev,
         trafficSources: prev.trafficSources.filter(src => src !== "Apple Search Ads"),
@@ -67,6 +70,7 @@ const Dashboard: React.FC = () => {
       console.debug('🚫 [Dashboard] Excluding Apple Search Ads from filter');
     } else {
       // Only add ASA back if it was previously filtered and we have other sources selected
+      setUserTouchedFilters(true);
       setFilters(prev => {
         if (prev.trafficSources.length > 0 && !prev.trafficSources.includes("Apple Search Ads")) {
           return { ...prev, trafficSources: [...prev.trafficSources, "Apple Search Ads"] };
@@ -75,7 +79,7 @@ const Dashboard: React.FC = () => {
       });
       console.debug('✅ [Dashboard] Including Apple Search Ads in filter');
     }
-  }, [excludeAsa, setFilters]);
+  }, [excludeAsa, setFilters, setUserTouchedFilters]);
 
   const periodComparison = useComparisonData("period");
   const yearComparison = useComparisonData("year");

--- a/src/pages/overview.tsx
+++ b/src/pages/overview.tsx
@@ -10,12 +10,13 @@ import { AiInsightsPanel } from "../components/AiInsightsPanel";
 import { AnalyticsTrafficSourceFilter } from "@/components/Filters";
 
 const OverviewPage: React.FC = () => {
-  const { data, loading, filters, setFilters } = useAsoData();
+  const { data, loading, filters, setFilters, setUserTouchedFilters } = useAsoData();
   const { current, previous, loading: comparisonLoading, deltas } = useComparisonData('period');
 
   // Handle traffic source filter change - now supports multi-select
   const handleSourceChange = (sources: string[]) => {
     console.log('🎯 [Overview] Multi-select traffic source filter changed:', sources);
+    setUserTouchedFilters(true);
     setFilters(prev => ({
       ...prev,
       trafficSources: sources


### PR DESCRIPTION
## Summary
- manage a `userTouchedFilters` flag in context
- prevent restoring saved filters once the user interacts
- mark filter usage in `AnalyticsTrafficSourceFilter`
- update Overview and Dashboard pages to record filter changes

## Testing
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68641dbf31988326aa41e301dfdcf9d2