### PR TITLE
Add readiness guard to BigQuery data hook

### DIFF
--- a/src/context/AsoDataContext.tsx
+++ b/src/context/AsoDataContext.tsx
@@ -141,10 +141,12 @@ export const AsoDataProvider: React.FC<AsoDataProviderProps> = ({ children }) =>
   }, [filters]);
 
   // Try BigQuery first
+  const bigQueryReady = filters.clients.length > 0;
   const bigQueryResult = useBigQueryData(
     filters.clients,
     filters.dateRange,
-    filters.trafficSources
+    filters.trafficSources,
+    bigQueryReady
   );
 
   // Mark when the initial unfiltered request has finished

--- a/src/hooks/useAsoDataWithFallback.ts
+++ b/src/hooks/useAsoDataWithFallback.ts
@@ -24,10 +24,12 @@ export const useAsoDataWithFallback = (
   const [dataSourceStatus, setDataSourceStatus] = useState<'loading' | 'bigquery-success' | 'bigquery-failed-fallback' | 'mock-only'>('loading');
 
   // Always fetch BigQuery data (unless explicitly set to mock-only)
+  const bigQueryReady = clientList.length > 0;
   const bigQueryResult = useBigQueryData(
     clientList,
     dateRange,
-    trafficSources
+    trafficSources,
+    bigQueryReady
   );
 
   // Always prepare mock data as fallback

--- a/src/hooks/useBigQueryData.ts
+++ b/src/hooks/useBigQueryData.ts
@@ -70,10 +70,19 @@ interface BigQueryDataResult {
   meta?: BigQueryMeta;
 }
 
+/**
+ * Fetch BigQuery ASO data for the given clients and date range.
+ *
+ * @param clientList - List of BigQuery client identifiers
+ * @param dateRange - Date range to query
+ * @param trafficSources - Optional traffic source filters
+ * @param ready - When false the hook will not fetch until true
+ */
 export const useBigQueryData = (
   clientList: string[],
   dateRange: DateRange,
-  trafficSources: string[]
+  trafficSources: string[],
+  ready: boolean = true
 ): BigQueryDataResult => {
   const [data, setData] = useState<AsoData | null>(null);
   const [loading, setLoading] = useState<boolean>(true);
@@ -84,6 +93,8 @@ export const useBigQueryData = (
   const { selectedApps } = useBigQueryAppSelection();
 
   useEffect(() => {
+    if (!clientList.length || !ready) return;
+
     const fetchBigQueryData = async () => {
       try {
         setLoading(true);
@@ -192,8 +203,9 @@ export const useBigQueryData = (
     clientList, 
     dateRange.from.toISOString().split('T')[0], // Only trigger on date changes
     dateRange.to.toISOString().split('T')[0], 
-    trafficSources, 
-    selectedApps
+    trafficSources,
+    selectedApps,
+    ready
   ]);
 
   return { data, loading, error, meta };

--- a/src/hooks/useComparisonData.ts
+++ b/src/hooks/useComparisonData.ts
@@ -44,14 +44,15 @@ export const useComparisonData = (type: ComparisonType): ComparisonData => {
   const { data: currentData, loading: currentLoading, error: currentError } = useAsoData();
 
   // Fetch previous period data
-  const { 
-    data: previousRawData, 
-    loading: previousLoading, 
-    error: previousError 
+  const {
+    data: previousRawData,
+    loading: previousLoading,
+    error: previousError
   } = useBigQueryData(
     filters.clients,
     previousDateRange,
-    filters.trafficSources
+    filters.trafficSources,
+    filters.clients.length > 0
   );
 
   const comparisonData = useMemo(() => {


### PR DESCRIPTION
## Summary
- add optional `ready` parameter to `useBigQueryData`
- guard fetching until clients are loaded or `ready` is true
- pass readiness flag from `AsoDataContext`, `useAsoDataWithFallback`, and `useComparisonData`

## Testing
- `npm run lint` *(fails: cannot satisfy lint rules)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6864246044ac8326914b34d6a3eddb56